### PR TITLE
Revert "Bump actions/upload-artifact from 2.2.4 to 2.3.1"

### DIFF
--- a/.github/workflows/staging-build-pr.yml
+++ b/.github/workflows/staging-build-pr.yml
@@ -130,7 +130,7 @@ jobs:
       # We are not willing to trust the rest (e.g. script/) for the remainder
       # of the deployment process.
       - name: Upload build artifact
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
+        uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
         with:
           name: pr_build
           path: app.tar


### PR DESCRIPTION
Reverts sega2424/docs#1